### PR TITLE
Fix pandas/numpy compatibility issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas>=1.5.0
+numpy==1.24.4
+pandas==2.0.3
 matplotlib>=3.6.0
 seaborn>=0.11.0
-numpy>=1.24.0
 Flask>=2.3.0


### PR DESCRIPTION
Fixes pandas/numpy binary incompatibility error in health analysis script.

Closes #2

## Changes
- Updated requirements.txt with compatible specific versions:
  - numpy==1.24.4
  - pandas==2.0.3

## Problem Solved
Fixed ValueError: numpy.dtype size changed error that prevented the health analysis script from running.

Co-authored-by: oto-hu <oto-hu@users.noreply.github.com>

Generated with [Claude Code](https://claude.ai/code)